### PR TITLE
#28 メンバー管理画面の修正＆その他画面の表示権限の設定見直し

### DIFF
--- a/BasketClub/src/main/java/jp/wat/basket/Repository/MemberRepository.java
+++ b/BasketClub/src/main/java/jp/wat/basket/Repository/MemberRepository.java
@@ -21,7 +21,7 @@ public interface MemberRepository extends JpaRepository<Member, Integer> {
 	*/
 	@Query(value="select m from Member m where deleteFlg = '0' order by nendo, teamKubun, no")	    // @Queryの標準の書き方（エンティティクラス名 エンティティクラスのカラム名を使用）
 	public List<Member> findAllMember();
-
+	
 	/**
 	 * メンバーIDをキーにメンバー情報を取得する
 	*/
@@ -38,13 +38,13 @@ public interface MemberRepository extends JpaRepository<Member, Integer> {
 	 * メンバーが存在する年度を全て取得する
 	 * 重複を排除して返却する
 	*/
-	@Query(value="select distinct m.nendo from Member m where deleteFlg = '0' order by nendo asc")	
+	@Query(value="select distinct m.nendo from Member m where deleteFlg = '0' order by nendo, teamKubun, no")	
 	public List<Integer> getNendoList();
 
 	/**
 	 * 年度をキーにメンバーを取得する
 	*/
-	@Query(value="select m from Member m where nendo = :nendo and deleteFlg = '0' order by no asc")	
+	@Query(value="select m from Member m where nendo = :nendo and deleteFlg = '0' order by nendo, teamKubun, no")	
 	public List<Member> findByNendo(Integer nendo);
 	
 }

--- a/BasketClub/src/main/java/jp/wat/basket/config/SecurityConfig.java
+++ b/BasketClub/src/main/java/jp/wat/basket/config/SecurityConfig.java
@@ -45,9 +45,25 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter{
     protected void configure(HttpSecurity http) throws Exception {
         // 認可の設定（ROLEは SpringSecurityがROLE_ をつけてチェックをする仕様のため「ROLE_」を除去した値を設定）
         http.authorizeRequests()
-            .antMatchers("/", "/index").permitAll() // indexは全ユーザーアクセス許可
-            .antMatchers("/user*", "/user/*").hasAnyRole("OFFICER", "ADMIN") // 利用者設定
-            .antMatchers("/*").hasAnyRole("PUBLIC", "OFFICER", "ADMIN") // 上記以外はROLEがないとアクセス不可
+            .antMatchers(
+            		"/",
+            		"/index"
+            		).permitAll() // indexは全ユーザーアクセス許可
+            		
+            .antMatchers(
+            		"/user**",
+            		"/user/**",
+            		"/member/regist/**",
+            		"/member/edit/**",
+            		"/schedule/edit/**"
+            		).hasAnyRole("OFFICER", "ADMIN") // 利用者設定
+            		
+            .antMatchers("/top",
+            		"/member",
+            		"/schedule**",
+            		"/info**"
+            		).hasAnyRole("PUBLIC", "OFFICER", "ADMIN") // 上記以外はROLEがないとアクセス不可
+
             .anyRequest().authenticated();
 
         // ログイン設定

--- a/BasketClub/src/main/java/jp/wat/basket/controller/MemberController.java
+++ b/BasketClub/src/main/java/jp/wat/basket/controller/MemberController.java
@@ -2,6 +2,7 @@ package jp.wat.basket.controller;
 
 import java.util.List;
 
+import jp.wat.basket.common.Util;
 import jp.wat.basket.entity.LoginUser;
 import jp.wat.basket.entity.Member;
 import jp.wat.basket.model.MemberViewModel;
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 public class MemberController {
@@ -22,16 +24,25 @@ public class MemberController {
 	@Autowired
 	CommonService commonService;
 	
-	@RequestMapping("/member")
-	public String index(Model model){
+	@Autowired
+	Util util;
 	
-		List<MemberViewModel> memberList = memberService.getAllMember();
+	@RequestMapping("/member")
+	public String index(@RequestParam(name = "nendo", required = false) Integer nendo, UserInfo userInfo,  Model model){
+		
+		Integer selectedNendo =  (nendo != null) ? nendo :  util.getNendo(userInfo);;
+		List<MemberViewModel> memberList = memberService.getMemberByNendo(selectedNendo);
+		
+		// 閲覧可能な年度の取得
+		List<Integer> nendoList = memberService.getMembersNendoList();
 		
 		// ユーザー情報取得
 		LoginUser loginUser = commonService.getLoginUser();
 		
 		model.addAttribute("userName", loginUser.getUserName());
 		model.addAttribute("memberList", memberList);
+		model.addAttribute("nendoList", nendoList);
+		model.addAttribute("selectedNendo", selectedNendo);
 		return "member";
 		
 	} 

--- a/BasketClub/src/main/java/jp/wat/basket/service/MemberService.java
+++ b/BasketClub/src/main/java/jp/wat/basket/service/MemberService.java
@@ -35,9 +35,10 @@ public class MemberService {
 	private UserMemberRepository userMemberRepository;
 	
 	
-	public List<MemberViewModel> getAllMember(){
+	public List<MemberViewModel> getMemberByNendo(Integer nendo){
+		
 		// 有効なメンバー情報を取得する
-		List<Member> memberList = repository.findAllMember();
+		List<Member> memberList = repository.findByNendo(nendo);
 		
 		List<MemberViewModel> memberViewModelList = new ArrayList<MemberViewModel>();
 		ModelMapper modelMapper = new ModelMapper();

--- a/BasketClub/src/main/resources/static/css/custom.css
+++ b/BasketClub/src/main/resources/static/css/custom.css
@@ -1,6 +1,11 @@
 @CHARSET "UTF-8";
 
 
+button:focus {
+    outline: 1px dotted;
+    /* outline: 5px auto -webkit-focus-ring-color; */
+}
+
 /*---------------------------------
   paper-kit.css カスタマイズ　start  
 -----------------------------------*/
@@ -56,6 +61,10 @@ div.label-btn {
   display: -ms-flex;
   display: -o-flex;
   display: flex;
+}
+
+h2.title {
+  margin-top:0;
 }
 
 h3.title {

--- a/BasketClub/src/main/resources/static/css/style.css
+++ b/BasketClub/src/main/resources/static/css/style.css
@@ -179,3 +179,17 @@ tr#templete {
 .checkbox-margin {
 	margin-left: 10px;
 }
+
+.member-nendo {
+	padding-right: 8px;
+	color: #c6c6c6!important;
+    font-size: 17px;
+    
+    !important;
+}
+
+.member-nendo-selected {
+	padding-right: 8px;
+	color: #464646 !important;
+	font-size: 17px;
+}

--- a/BasketClub/src/main/resources/templates/member.html
+++ b/BasketClub/src/main/resources/templates/member.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html xmlns:th="http://www.thymeleaf.org"
+	xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
 	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
 	layout:decorate="~{layout/layout}">
 <head>
@@ -64,7 +65,7 @@ p.msg {
 							</div>
 						</div>
 						<div>
-							<a href="/member/regist/input" class="btn btn-info">新規メンバー登録</a>
+							<a href="/member/regist/input" sec:authorize="hasAnyRole('ROLE_ADMIN','ROLE_OFFICER')" class="btn btn-info">新規メンバー登録</a>
 						</div>
 					</div>
 					<div class="row">
@@ -90,8 +91,8 @@ p.msg {
 									<td th:text="${member.memberName}" class="vertical-min wid30"></td>
 									<td th:text="${member.grade}" class="vertical-min"></td>
 									<td class="vertical-min">
-									  <a th:href="@{'member/edit/input/' + ${member.memberId}}" class="btn btn-info btn-mgin-pd-01 btn-hidden">編集</a>
-									  <a th:href="@{'member/delete/confirm/' + ${member.memberId}}" class="btn btn-info btn-mgin-pd-01 btn-hidden">削除</a>
+									  <a th:href="@{'member/edit/input/' + ${member.memberId}}" sec:authorize="hasAnyRole('ROLE_ADMIN','ROLE_OFFICER')" class="btn btn-info btn-mgin-pd-01 btn-hidden">編集</a>
+									  <a th:href="@{'member/delete/confirm/' + ${member.memberId}}" sec:authorize="hasAnyRole('ROLE_ADMIN','ROLE_OFFICER')" class="btn btn-info btn-mgin-pd-01 btn-hidden">削除</a>
 									</td>
 								</tr>
 							</tbody>

--- a/BasketClub/src/main/resources/templates/member.html
+++ b/BasketClub/src/main/resources/templates/member.html
@@ -31,8 +31,24 @@ p.msg {
 				<div class="container">
 					<div class="" role="alert" th:id="flash-message"  th:text="${message}"></div>
 					<div class="tim-title">
-						<h2>メンバー情報一覧</h2>
+						<div class="label-btn">
+							<div>
+								<h2 class="title">メンバー情報一覧</h2>
+							</div>
+							<div>
+								<h3 class="title"></h3>
+							</div>
+							<div class="btn-group">
+								<a th:each="nendo: ${nendoList}" 
+								class="btn btn-link" 
+								th:classappend="${nendo}==${selectedNendo} ? 'member-nendo-selected' : 'member-nendo'"
+								th:href="@{/member?nendo=} + ${nendo}" 
+								th:name="select + ${nendo}" th:text="@{${nendo} + '年度'}">
+								</a>
+							</div>
+						</div>
 					</div>
+					
 					<div class="tim-title label-btn">
 						<div class="label-btn">
 							<div>
@@ -43,6 +59,9 @@ p.msg {
 							 	<button class="changeTeam" type="button" th:name="selectall">ALL</button>
 							 	<button class="changeTeam" type="button" th:name="selectyabedan">ヤベダン</button>
 							</div>
+							<div>
+								<h3 class="title"></h3>
+							</div>
 						</div>
 						<div>
 							<a href="/member/regist/input" class="btn btn-info">新規メンバー登録</a>
@@ -52,7 +71,7 @@ p.msg {
 						<table class="table table-hover ">
 							<thead>
 								<tr>
-									<th class="wid4">チーム</th>
+									<th class="wid9">チーム</th>
 									<th>背番号</th>
 									<th>名前</th>
 									<th>学年</th>

--- a/BasketClub/src/main/resources/templates/schedule.html
+++ b/BasketClub/src/main/resources/templates/schedule.html
@@ -62,7 +62,7 @@ p.msg {
 							<h3 th:text="|${month}月 スケジュール|"></h3>
 						</div>
 						<div>
-							<a th:href="@{'schedule/edit/' + ${month}}" class="btn btn-info btn-mgin-pd-03">スケジュール編集</a>
+							<a th:href="@{'schedule/edit/' + ${month}}" sec:authorize="hasAnyRole('ROLE_ADMIN','ROLE_OFFICER')" class="btn btn-info btn-mgin-pd-03">スケジュール編集</a>
 						</div>
 					</div>
 					<div class="row">


### PR DESCRIPTION
・年度のフィルターを追加
・表示権限の整理（メンバー登録、変更、削除は役員、管理者のみ実行可能）
・合わせて、その他の画面の表示権限の見直し
