### PR TITLE
#28 メンバー管理画面の修正

### DIFF
--- a/BasketClub/src/main/java/jp/wat/basket/controller/MemberEditController.java
+++ b/BasketClub/src/main/java/jp/wat/basket/controller/MemberEditController.java
@@ -201,6 +201,38 @@ public class MemberEditController {
 		return "redirect:/member";
 	}
 	
+	/////////////////////////////////////////////////////////
+	// メンバー詳細設定
+	/////////////////////////////////////////////////////////
+	
+	/**
+	 *  メンバー詳細画面　表示
+	 * @param mid
+	 * @param userInfo
+	 * @param model
+	 * @return
+	 */
+	@RequestMapping(value="/member/memberDetail/{mid}", method=RequestMethod.GET)
+	public String registDetailInput(@PathVariable("mid") String mid, UserInfo userInfo, Model model){
+		
+		//変更前情報取得
+		Member member = memberService.findById(Integer.parseInt(mid));
+		ModelMapper modelMapper = new ModelMapper();
+		MemberForm befMemberForm = modelMapper.map(member, MemberForm.class);
+
+		model.addAttribute("EnumTeam", EnumTeamKubun.decode(befMemberForm.getTeamKubun()));
+		model.addAttribute("EnumGrade", EnumGrade.decode(befMemberForm.getGrade()));
+		model.addAttribute("EnumSebango", EnumSebango.decode(befMemberForm.getNo()));
+		
+		// ユーザー情報取得
+		LoginUser loginUser = commonService.getLoginUser();
+		
+		model.addAttribute("userName", loginUser.getUserName());
+		model.addAttribute("memberForm", befMemberForm);
+		
+		return "/member/memberDetail";
+	}
+	
 	/*
 	 * MemberForm オブジェクトの内容をlogに出力する
 	 */

--- a/BasketClub/src/main/java/jp/wat/basket/controller/MemberEditController.java
+++ b/BasketClub/src/main/java/jp/wat/basket/controller/MemberEditController.java
@@ -44,114 +44,7 @@ public class MemberEditController {
 	
 	@Autowired
 	CommonService commonService;
-
-	/********************************************************
-	 * メンバー登録
-	 *******************************************************/
-	// 登録画面　表示
-	@RequestMapping(value="/member/regist/input", method=RequestMethod.GET)
-	public String registInput(UserInfo userInfo, Model model){
 	
-		userInfo.setStartViewName("/member/regist/input");
-		
-		// セレクトボックスのItemを取得（チーム区分、学年、背番号）
-		model.addAttribute("selectTeam", EnumTeamKubun.values());
-		model.addAttribute("selectGrade", EnumGrade.values());
-		model.addAttribute("selectNo", EnumSebango.values());
-		
-		// ユーザー情報取得
-		LoginUser loginUser = commonService.getLoginUser();
-		
-		model.addAttribute("userName", loginUser.getUserName());
-		model.addAttribute("memberForm", new MemberForm());
-		
-		return "/member/regist/input";
-	}
-	
-	// 登録画面　キャンセル
-	@RequestMapping(value = "/member/regist/confirm", method = RequestMethod.POST, params = "cancel")
-	public String registCancel(Model model) {
-		return "redirect:/member";
-	}
-	
-	// 登録確認画面　表示
-	@RequestMapping(value = "/member/regist/confirm", method = RequestMethod.POST, params = "confirm")
-	public String registConfirm(
-			@Validated MemberForm memberForm,
-			BindingResult result,
-			Model model) {
-
-		loggerInfoMemberForm(memberForm);
-		
-		if(result.hasErrors()){
-			//TODO URLが変わってしまい、キャンセルボタンでエラーが発生する
-			return "/member/regist/input";
-		}
-		
-//		//重複チェック
-//		Member befMember = memberService.findByNo(memberForm.getNo());
-//		
-//		//TODO 背番号の重複チェック
-//		if(befMember != null){
-//			model.addAttribute("message", "登録済みの背番号です");
-//			return "/member/edit";
-//		}
-		
-		//TODO 変更時の変更有無チェック
-		//TODO Formに変更有無を追加して、チェック結果を格納
-		
-		model.addAttribute("EnumTeam", EnumTeamKubun.decode(memberForm.getTeamKubun()));
-		model.addAttribute("EnumGrade", EnumGrade.decode(memberForm.getGrade()));
-		model.addAttribute("EnumNo", EnumSebango.decode(memberForm.getNo()));
-		
-		// ユーザー情報取得
-		LoginUser loginUser = commonService.getLoginUser();
-		
-		model.addAttribute("userName", loginUser.getUserName());
-		model.addAttribute("memberForm", memberForm);
-		return "/member/regist/confirm";
-	}
-	
-	// 登録／変更処理（共通）
-	@RequestMapping(value={"/member/regist/transactfinish","/member/edit/transactfinish"}, method=RequestMethod.POST, params="submit")
-	public String registComplete(@Validated MemberForm form, UserInfo userInfo,BindingResult result, SessionStatus sessionStatus, Model model,
-			RedirectAttributes redirectAttributes){
-
-		ModelMapper modelMapper = new ModelMapper();
-		Member member = modelMapper.map(form, Member.class);
-				
-		// 共通項目の設定
-		LoginUser loginUser = commonService.getLoginUser();
-		member.setDeleteFlg(0);
-		member.setRegistUser(loginUser.getUserId());
-		member.setRegistTime(new Timestamp(System.currentTimeMillis()));
-		member.setUpdateUser(loginUser.getUserId());
-		member.setUpdateTime(new Timestamp(System.currentTimeMillis()));
-		
-		logger.info("[member登録／member更新]");
-		loggerInfoMember(member);
-
-		// DB更新処理 
-		memberService.registMember(member);
-		
-		String nextViewName = userInfo.getStartViewName();
-		sessionStatus.setComplete();
-		
-		// 登録／編集判定
-		if(nextViewName.equals("/member/regist/input")){
-			redirectAttributes.addFlashAttribute("message","登録が完了しました");
-			return "redirect:/member/regist/input";
-			
-		} else if(nextViewName.equals("/member/edit/input")){
-			redirectAttributes.addFlashAttribute("message","更新が完了しました");
-			return "redirect:/member";
-			
-		} else {
-			//異常値の場合はトップに遷移
-			return "redirect:/";
-		}
-	}	
-
 	/********************************************************
 	 * メンバー変更
 	 *******************************************************/
@@ -204,7 +97,6 @@ public class MemberEditController {
 		
 		//TODO バリデーションチェック
 		
-		
 		// 変更前用のEnumを取得（チーム区分、学年、背番号）
 		model.addAttribute("befEnumTeam", EnumTeamKubun.decode(befMemberForm.getTeamKubun()));
 		model.addAttribute("befEnumGrade", EnumGrade.decode(befMemberForm.getGrade()));
@@ -225,8 +117,34 @@ public class MemberEditController {
 		return "/member/edit/editConfirm";
 	}
 	
+	// 変更処理
+	@RequestMapping(value={"/member/edit/transactfinish"}, method=RequestMethod.POST, params="submit")
+	public String registComplete(@Validated MemberForm form, UserInfo userInfo,BindingResult result, SessionStatus sessionStatus, Model model,
+			RedirectAttributes redirectAttributes){
+
+		ModelMapper modelMapper = new ModelMapper();
+		Member member = modelMapper.map(form, Member.class);
+				
+		// 共通項目の設定
+		LoginUser loginUser = commonService.getLoginUser();
+		member.setDeleteFlg(0);
+		member.setRegistUser(loginUser.getUserId());
+		member.setRegistTime(new Timestamp(System.currentTimeMillis()));
+		member.setUpdateUser(loginUser.getUserId());
+		member.setUpdateTime(new Timestamp(System.currentTimeMillis()));
+		
+		logger.info("[member更新]");
+		loggerInfoMember(member);
+
+		// DB更新処理 
+		memberService.registMember(member);
+		
+		redirectAttributes.addFlashAttribute("message","更新が完了しました");
+		return "redirect:/member";
+	}	
+	
 	// ブラウザバック対策
-	@RequestMapping(value={"/member/edit/confirm", "/member/confirm"}, method=RequestMethod.GET)
+	@RequestMapping(value={"/member/edit/confirm"}, method=RequestMethod.GET)
 	public String registConfirmBack(Model model){
 		return "redirect:/member";
 	}

--- a/BasketClub/src/main/java/jp/wat/basket/controller/MemberRegistController.java
+++ b/BasketClub/src/main/java/jp/wat/basket/controller/MemberRegistController.java
@@ -1,0 +1,191 @@
+package jp.wat.basket.controller;
+
+import java.sql.Timestamp;
+
+import jp.wat.basket.common.Enum.EnumGrade;
+import jp.wat.basket.common.Enum.EnumSebango;
+import jp.wat.basket.common.Enum.EnumTeamKubun;
+import jp.wat.basket.entity.LoginUser;
+import jp.wat.basket.entity.Member;
+import jp.wat.basket.form.MemberForm;
+import jp.wat.basket.form.UserForm;
+import jp.wat.basket.service.CommonService;
+import jp.wat.basket.service.MemberService;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.SessionAttributes;
+import org.springframework.web.bind.support.SessionStatus;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Controller
+@SessionAttributes(value={"userInfo"})
+@EnableWebSecurity
+public class MemberRegistController {
+	private static final Logger logger = LoggerFactory.getLogger(MemberRegistController.class);
+	
+	@ModelAttribute("userInfo")
+	UserInfo userInfo() {
+	    return new UserInfo();
+	}
+	
+	@Autowired
+	MemberService memberService;
+	
+	@Autowired
+	CommonService commonService;
+
+	// 登録画面　表示
+	@RequestMapping(value="/member/regist/input", method=RequestMethod.GET)
+	public String registInput(UserInfo userInfo, ModelMap model){
+	
+		userInfo.setStartViewName("/member/regist/input");
+		
+		// セレクトボックスのItemを取得（チーム区分、学年、背番号）
+		model.addAttribute("selectTeam", EnumTeamKubun.values());
+		model.addAttribute("selectGrade", EnumGrade.values());
+		model.addAttribute("selectNo", EnumSebango.values());
+		
+		// ユーザー情報取得
+		LoginUser loginUser = commonService.getLoginUser();
+		
+		// 確認画面で修正ボタンを押下してリダイレクトしてきた時はフォームの入力内容（memberForm）が Modelオブジェクトに設定されている
+		// 初期画面表示時はuserFormは設定されていないため新規作成する
+		MemberForm memberForm = model.containsKey("memberForm")? (MemberForm) model.get("memberForm") : new MemberForm();
+		
+		model.addAttribute("userName", loginUser.getUserName());
+		model.addAttribute("memberForm", memberForm);
+		
+		return "/member/regist/memberRegistInput";
+	}
+	
+	// 登録画面　キャンセル
+	@RequestMapping(value = "/member/regist/confirm", method = RequestMethod.POST, params = "cancel")
+	public String registCancel(Model model) {
+		return "redirect:/member";
+	}
+	
+	// 登録確認画面　表示
+	@RequestMapping(value = "/member/regist/confirm", method = RequestMethod.POST, params = "confirm")
+	public String registConfirm(
+			@Validated MemberForm memberForm,
+			BindingResult result,
+			Model model) {
+
+		loggerInfoMemberForm(memberForm);
+		
+		if(result.hasErrors()){
+			//TODO URLが変わってしまい、キャンセルボタンでエラーが発生する
+			model.addAttribute("selectTeam", EnumTeamKubun.values());
+			model.addAttribute("selectGrade", EnumGrade.values());
+			model.addAttribute("selectNo", EnumSebango.values());
+			return "/member/regist/memberRegistInput";
+		}
+		
+		//TODO 変更時の変更有無チェック
+		//TODO Formに変更有無を追加して、チェック結果を格納
+		
+		model.addAttribute("EnumTeam", EnumTeamKubun.decode(memberForm.getTeamKubun()));
+		model.addAttribute("EnumGrade", EnumGrade.decode(memberForm.getGrade()));
+		model.addAttribute("EnumNo", EnumSebango.decode(memberForm.getNo()));
+		
+		// ユーザー情報取得
+		LoginUser loginUser = commonService.getLoginUser();
+		
+		model.addAttribute("userName", loginUser.getUserName());
+		model.addAttribute("memberForm", memberForm);
+		return "/member/regist/memberRegistConfirm";
+	}
+	
+	// 登録処理
+	@RequestMapping(value={"/member/regist/transactfinish"}, method=RequestMethod.POST)
+	public String registComplete(@Validated MemberForm form, UserInfo userInfo,BindingResult result, SessionStatus sessionStatus, Model model,
+			RedirectAttributes redirectAttributes){
+
+		ModelMapper modelMapper = new ModelMapper();
+		Member member = modelMapper.map(form, Member.class);
+				
+		// 共通項目の設定
+		LoginUser loginUser = commonService.getLoginUser();
+		member.setDeleteFlg(0);
+		member.setRegistUser(loginUser.getUserId());
+		member.setRegistTime(new Timestamp(System.currentTimeMillis()));
+		member.setUpdateUser(loginUser.getUserId());
+		member.setUpdateTime(new Timestamp(System.currentTimeMillis()));
+		
+		logger.info("[member登録]");
+		loggerInfoMember(member);
+
+		// DB更新処理 
+		memberService.registMember(member);
+		
+		// 登録
+		redirectAttributes.addFlashAttribute("message","登録が完了しました");
+		return "redirect:/member/regist/input";
+	}	
+
+	// ブラウザバック対策
+	@RequestMapping(value={"/member/confirm"}, method=RequestMethod.GET)
+	public String registConfirmBack(Model model){
+		return "redirect:/member";
+	}
+	
+	/**
+	 *  登録確認画面　キャンセル
+	 * @param model
+	 * @return
+	 */
+	@RequestMapping(value = "/member/regist/registCancel", method = RequestMethod.POST)
+	public String registCorrect(MemberForm memberForm, Model model, RedirectAttributes redirectAttributes) {
+		redirectAttributes.addFlashAttribute("memberForm", memberForm);
+		return "redirect:/member/regist/input";
+	}
+	
+	@ExceptionHandler(RuntimeException.class)
+	public String handleRuntimeException(RuntimeException exception, RedirectAttributes redirectAttributes) {
+		
+		logger.error("RuntimeExceptionHandler", exception);
+	    redirectAttributes.addFlashAttribute("errorMessage","想定外のエラーが発生しました。<br>操作をやり直してください。");
+	    
+		//メンバー一覧に遷移
+		return "redirect:/member";
+	}
+	
+	/*
+	 * MemberForm オブジェクトの内容をlogに出力する
+	 */
+	private void loggerInfoMemberForm(MemberForm memberForm){
+		
+		logger.info("memberForm.memberId : " + memberForm.getMemberId());
+		logger.info("memberForm.no : " + memberForm.getNo());
+		logger.info("memberForm.name : " + memberForm.getMemberName());
+		logger.info("memberForm.namekana : " + memberForm.getMemberNameKn());
+		logger.info("memberForm.grade : " + memberForm.getGrade());
+	}
+	
+	/*
+	 * Member オブジェクトの内容をlogに出力する
+	 */
+	private void loggerInfoMember(Member member){
+		
+		logger.info("member.memberId : " + member.getMemberId());
+		logger.info("member.no : " + member.getNo());
+		logger.info("member.name : " + member.getMemberName());
+		logger.info("member.namekana : " + member.getMemberNameKn());
+		logger.info("member.grade : " + member.getGrade());
+	}
+	
+}

--- a/BasketClub/src/main/resources/static/js/memberedit.js
+++ b/BasketClub/src/main/resources/static/js/memberedit.js
@@ -1,0 +1,62 @@
+$(function(){
+	
+	$('#submitbtn').on("click", function(){
+		// 確認ダイアログを出して、変更をする
+				
+		swal({
+			  text: "入力した内容でデータを更新してよいですか？",
+			  type: "info",
+			  showCancelButton: true,
+			  confirmButtonText: 'OK',
+		      allowOutsideClick: false
+		}).then(function(isConfirm){
+			if (isConfirm.value) {
+			      // OKボタンが押された時はユーザー情報の更新をおこなう
+				 $('#memberUpdateForm').submit();
+			} else {
+			      // キャンセルボタンを押した時の処理
+			}
+		});
+	});
+		
+	$('#cancelbtn').on("click", function(){
+		// 確認ダイアログを出して、編集内容を破棄してよいか確認する
+		swal({
+			  text: "編集内容をクリアして前画面に戻りますがよいですか？",
+			  type: "info",
+			  showCancelButton: true,
+			  confirmButtonText: 'OK',
+		      allowOutsideClick: false
+		}).then(function(isConfirm){
+			if (isConfirm.value) {
+				// OKボタン押下時処理
+				// 変更後ユーザー詳細画面に遷移する
+				$memberId = $('#memberId').val();
+			    window.location.href = '/member/memberDetail/' + $memberId;
+			}else{
+				// キャンセルボタン押下時処理
+			}
+		});	
+	});
+	
+	$('#deletelbtn').on("click", function(){
+		// 確認ダイアログを出して、削除してよいか確認する
+		swal({
+			  text: "ユーザーを削除してよろしいですか？",
+			  type: "info",
+			  showCancelButton: true,
+			  confirmButtonText: 'OK',
+		      allowOutsideClick: false
+		}).then(function(isConfirm){
+			if (isConfirm.value) {
+				// OKボタンが押された時はユーザー情報の削除を行う				
+				 $('#memberdelete').submit();
+			}else{
+				// キャンセルボタン押下時処理
+				// 何もせずダイアログを閉じる
+			}
+		});	
+	});
+	
+});
+	

--- a/BasketClub/src/main/resources/templates/member.html
+++ b/BasketClub/src/main/resources/templates/member.html
@@ -91,8 +91,7 @@ p.msg {
 									<td th:text="${member.memberName}" class="vertical-min wid30"></td>
 									<td th:text="${member.grade}" class="vertical-min"></td>
 									<td class="vertical-min">
-									  <a th:href="@{'member/edit/input/' + ${member.memberId}}" sec:authorize="hasAnyRole('ROLE_ADMIN','ROLE_OFFICER')" class="btn btn-info btn-mgin-pd-01 btn-hidden">編集</a>
-									  <a th:href="@{'member/delete/confirm/' + ${member.memberId}}" sec:authorize="hasAnyRole('ROLE_ADMIN','ROLE_OFFICER')" class="btn btn-info btn-mgin-pd-01 btn-hidden">削除</a>
+									  <a th:href="@{'member/memberDetail/' + ${member.memberId}}" class="btn btn-info btn-mgin-pd-01 btn-hidden">詳細</a>
 									</td>
 								</tr>
 							</tbody>

--- a/BasketClub/src/main/resources/templates/member/edit/memberEditInput.html
+++ b/BasketClub/src/main/resources/templates/member/edit/memberEditInput.html
@@ -32,7 +32,7 @@ p.msg {
 					<div class="tim-title">
 						<h2 th:text="メンバー編集"></h2>
 					</div>
-					<form th:method="post" th:action="@{'/member/edit/confirm'}" th:object="${memberForm}">
+					<form th:method="post" th:action="@{'/member/edit/transactfinish'}" th:object="${memberForm}" th:id="memberUpdateForm">
 					<div class="row">
 						<div class="col-sm-3">
 							<div class="form-group" th:classappend="${#fields.hasErrors('nendo')}? has-error">
@@ -101,11 +101,11 @@ p.msg {
 					</div>
                      <div class="row submit-btn-parents">
 						<div>
-							<input type="submit" class="btn btn-primary btn-mgin-pd-03" name="cancel" value="　戻　る　"/>
+							<input type="button" id="cancelbtn" class="btn btn-primary btn-mgin-pd-03" value="　戻　る　"/>
 						</div>
 						<div>
 							<input type="hidden" th:field="*{memberId}" th:value="${memberId}" />
-							<input type="submit" class="btn btn-primary btn-mgin-pd-03" name="confirm" value="確認画面へ"/>
+							<input type="button" id="submitbtn" class="btn btn-primary btn-mgin-pd-03"  value="変更する"/>
 						</div>
                     </div>
                     </form>
@@ -122,7 +122,9 @@ p.msg {
 	type="text/javascript"></script>
 <script src="/bootstrap/assets/js/tether.min.js" type="text/javascript"></script>
 <script src="/bootstrap/assets/js/bootstrap.min.js" type="text/javascript"></script>
+<script src="/sweetalert/js/sweetalert2.min.js" type="text/javascript"></script>
 <script src="/js/common.js" type="text/javascript" ></script>
+<script src="/js/memberedit.js" type="text/javascript" ></script>
 
 <!--  Paper Kit Initialization snd functons -->
 <!--  <script src="/bootstrap/assets/js/paper-kit.js?v=2.0.1"></script> -->

--- a/BasketClub/src/main/resources/templates/member/memberDetail.html
+++ b/BasketClub/src/main/resources/templates/member/memberDetail.html
@@ -77,9 +77,9 @@ p.msg {
 			</div>
 		</div>
 		<div>
-		<form th:action="@{/member/delete/transactfinish}" th:id="memerdelete" th:class="none" th:method="POST" th:object="${memberForm}">
+		<form th:action="@{/member/delete/transactfinish}" th:id="memberdelete" th:class="none" th:method="POST" th:object="${memberForm}">
 			<input type="hidden" th:name="memberId" th:value="${memberForm.memberId}">
-			<input type="submit" id="deleteSubmitBtn">
+			<input type="submit" id="deletelbtn">
 		</form>
 		</div>
 	</div>
@@ -94,7 +94,7 @@ p.msg {
 <script src="/sweetalert/js/sweetalert2.min.js" type="text/javascript"></script>
 <script src="/js/common.js" type="text/javascript" ></script>
 <script src="/js/member.js" type="text/javascript" ></script>
-<script src="/js/useredit.js" type="text/javascript" ></script>
+<script src="/js/memberedit.js" type="text/javascript" ></script>
 
 <!-- Plugin for Switches -->
 <script src="/bootstrap/assets/js/bootstrap-switch.min.js"></script>
@@ -104,7 +104,6 @@ p.msg {
 
 <!--  Paper Kit Initialization snd functons -->
 <script src="/bootstrap/assets/js/paper-kit.js?v=2.0.1"></script>
-<script src="/js/user.js"></script>
 <script type="text/javascript">
 
 $(document).ready( function() {

--- a/BasketClub/src/main/resources/templates/member/memberDetail.html
+++ b/BasketClub/src/main/resources/templates/member/memberDetail.html
@@ -29,69 +29,56 @@ p.msg {
 		<div class="main">
 		<div class="section section-buttons">
                 <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a th:href="@{/user}">ユーザー情報一覧</a></li>
-                    <li class="breadcrumb-item active"><a th:text="|${userForm.userId} さん|"></a></li>
+                    <li class="breadcrumb-item"><a th:href="@{/member}">メンバー情報一覧</a></li>
+                    <li class="breadcrumb-item active"><a th:text="|${memberForm.memberName} |"></a></li>
                 </ol>
 				<div class="container">   
 					<div class="alert alert-success" role="alert" th:id="flash-message" th:if="${message}" th:text="${message}">フラッシュメッセージ</div>
 					<div class="alert alert-error" role="alert" th:id="flash-err-message" th:if="${errorMessage}" th:text="${errorMessage}">フラッシュエラーメッセージ</div>
 					<div class="tim-title label-btn">
 						<div>
-							<h3 class="mt-2">登録情報</h3>
+							<h3 class="mt-2">メンバー情報</h3>
 						</div>
 						<div>
-							<a th:href="@{/user/edit/input/{uid}(uid=${userForm.userId})}" class="btn btn-info">編集</a>
+							<a th:href="@{/member/edit/input/{mid}(mid=${memberForm.memberId})}" class="btn btn-info">編集</a>
                             <button type="button" id="deletelbtn" class="btn btn-info">削除</button>
 						</div>
 					</div>
 					<div>
 						<table class="table">
 								<tr>
-                                    <th class="w-25">ユーザーID</th>
-                                    <td th:id="userId" th:text="${userForm.userId}"></td>
+                                    <th class="w-25">対象年度</th>
+                                    <td th:id="nendo" th:text="${memberForm.nendo}"></td>
+								</tr>
+								<tr>
+                                    <th>チーム</th>
+                                    <td th:text="${EnumTeam.name}"></td>
 								</tr>
                             	<tr>
-                                    <th>ユーザー名</th>
-                                    <td th:text="${userForm.userName}"></td>
+                                    <th>背番号</th>
+                                    <td th:text="${EnumSebango.name}"></td>
 								</tr>
                             	<tr>
-                                    <th>ユーザー名カナ</th>
-                                    <td th:text="${userForm.userNameKn}"></td>
+                                    <th>名前</th>
+                                    <td th:text="${memberForm.memberName}"></td>
 								</tr>
                             	<tr>
-                                    <th>権限</th>
-                                    <td th:text="${EnumRole.name}"></td>
+                                    <th>名前（カナ）</th>
+                                    <td th:text="${memberForm.memberNameKn}"></td>
 								</tr>
-                            	<tr>
-                                    <th>メールアドレス</th>
-                                    <td th:text="${userForm.mail}"></td>
+								<tr>
+                                    <th>学年</th>
+                                    <td th:text="${EnumGrade.name}"></td>
 								</tr>
 						</table>
 					</div>
 					
-                    <div class="tim-title label-btn">
-						<div>
-							<h3 class="mt-2">閲覧設定</h3>
-						</div>
-                        <div>
-							<a th:href="@{/user/usersMember(uid=${userForm.userId})}" class="btn btn-info">設定変更</a>
-						</div>
-					</div>
-                    <div th:each="nendo: ${nendoKeys.keySet()}">
-						<table class="table">
-								<tr>
-                                    <th class="w-25" th:text="|${nendo}年度|"></th>
-                                    <td th:each="member: ${nendoKeys.get(nendo)}" th:if="${nendo} == ${member.nendo}" th:text="|${member.memberName}（${member.grade}年）|"></td>
-                                    <td></td>
-								</tr>
-						</table>
-					</div>
 				</div>
 			</div>
 		</div>
 		<div>
-		<form th:action="@{/user/delete/transactfinish}" th:id="userdelete" th:class="none" th:method="POST" th:object="${userForm}">
-			<input type="hidden" th:name="userId" th:value="${userForm.userId}">
+		<form th:action="@{/member/delete/transactfinish}" th:id="memerdelete" th:class="none" th:method="POST" th:object="${memberForm}">
+			<input type="hidden" th:name="memberId" th:value="${memberForm.memberId}">
 			<input type="submit" id="deleteSubmitBtn">
 		</form>
 		</div>

--- a/BasketClub/src/main/resources/templates/member/regist/memberRegistConfirm.html
+++ b/BasketClub/src/main/resources/templates/member/regist/memberRegistConfirm.html
@@ -29,9 +29,9 @@ p.msg {
 			<div class="section section-buttons">
 				<div class="container">
 					<div class="tim-title">
-					    <h2 th:text="${session.userInfo.startViewName}=='/member/edit'? 'メンバー編集確認': 'メンバー登録確認'"></h2>
+					    <h2 th:text="メンバー登録確認"></h2>
 					</div>
-					<form method="post" th:action="transactfinish" th:object="${memberForm}">
+					<form method="post" th:action="transactfinish" th:object="${memberForm}" th:name="registForm">
 						<div class="row">
 
 							<table class="table table-bordered"
@@ -75,11 +75,11 @@ p.msg {
 						<div>
 							<div class="row submit-btn-parents">
 								<div>
-									<input type="button" class="btn btn-primary btn-mgin-pd-03" onclick="history.back();" value="修正する"/>
+									<input type="button" class="btn btn-primary btn-mgin-pd-03" onClick="registCancel();" value="修正する"/>
 								</div>
 								<div>
 									<input type="hidden" th:field="*{memberId}" th:value="${memberId}" />
-									<input type="submit" class="btn btn-primary btn-mgin-pd-03" name="submit" value="登録する" />
+									<input type="button" class="btn btn-primary btn-mgin-pd-03" onClick="registSubmit();" value="登録する" />
 								</div>
 							</div>
 						</div>
@@ -104,4 +104,27 @@ p.msg {
 <!--  Paper Kit Initialization snd functons -->
 <!--  <script src="/bootstrap/assets/js/paper-kit.js?v=2.0.1"></script> -->
 
+<script type="text/javascript">
+$(document).ready( function() {
+	
+	$message = $('#flash-message').text();
+	
+	if ($message != null && $message != "") {
+		flashMessage($message, "success");	
+	}
+});
+
+// 修正するボタン押下時処理
+function registCancel(){
+    document.registForm.action = 'registCancel';
+    document.registForm.submit();
+}
+
+// 登録するボタン押下時処理
+function registSubmit(){
+    document.registForm.action = 'transactfinish';
+    document.registForm.submit();
+}
+
+</script>
 </html>

--- a/BasketClub/src/main/resources/templates/member/regist/memberRegistInput.html
+++ b/BasketClub/src/main/resources/templates/member/regist/memberRegistInput.html
@@ -35,7 +35,7 @@ p.msg {
 					<form th:method="post" th:action="confirm" th:object="${memberForm}">
 					<div class="row">
 						<div class="col-sm-3">
-							<div class="form-group" th:classappend="${#fields.hasErrors('nendo')}? has-error">
+							<div class="form-group">
 								<label class="control-label">対象年度</label>
 								<select class="form-control" th:field="*{nendo}">
 								<option th:value="2018" th:text="2018"></option>
@@ -47,7 +47,7 @@ p.msg {
 					</div>
 					<div class="row">
 						<div class="col-sm-3">
-							<div class="form-group" th:classappend="${#fields.hasErrors('teamKubun')}? has-error">
+							<div class="form-group">
 								<label class="control-label">チーム</label>
 								<select class="form-control" th:field="*{teamKubun}">
 								<option value="">---</option>
@@ -59,7 +59,7 @@ p.msg {
 					</div>
 					<div class="row">
 						<div class="col-sm-3">
-							<div class="form-group" th:classappend="${#fields.hasErrors('no')}? has-error">
+							<div class="form-group">
 								<label class="control-label">背番号</label>
 								<select class="form-control" th:field="*{no}">
 								<option value="">---</option>
@@ -71,7 +71,7 @@ p.msg {
 					</div>
 					<div class="row">
 						<div class="col-sm-3">
-							<div class="form-group" th:classappend="${#fields.hasErrors('memberName')}? has-error">
+							<div class="form-group">
 								<label class="control-label">名前</label>
 								<input type="text" class="form-control" th:field="*{memberName}">
 								<span class="text-danger" th:if="${#fields.hasErrors('memberName')}" th:errors="*{memberName}"></span>
@@ -80,7 +80,7 @@ p.msg {
 					</div>
 					<div class="row">
 						<div class="col-sm-3">
-							<div class="form-group" th:classappend="${#fields.hasErrors('memberNameKn')}? has-error">
+							<div class="form-group">
 								<label class="control-label">名前（カナ）</label>
 								<input type="text" class="form-control" th:field="*{memberNameKn}">
 								<span class="text-danger" th:if="${#fields.hasErrors('memberNameKn')}" th:errors="*{memberNameKn}"></span>
@@ -89,7 +89,7 @@ p.msg {
 					</div>
 					<div class="row">
 						<div class="col-sm-3">
-							<div class="form-group" th:classappend="${#fields.hasErrors('grade')}? has-error">
+							<div class="form-group">
 								<label class="control-label">学年</label>
 								<select class="form-control" th:field="*{grade}">
 								<option value="">---</option>


### PR DESCRIPTION
・メンバー登録機能を編集機能のControllerから分離
・詳細画面を追加して、変更画面と削除画面の遷移ルートは詳細画面に変更
・メンバー情報変更の確認画面を削除して画面遷移せずに上書き更新するように改修
・メンバー情報削除の確認画面をダイアログに変更